### PR TITLE
Fixed early disposal of ECDsa and RSA keys

### DIFF
--- a/Frends.OAuth.CreateJWTToken/CHANGELOG.md
+++ b/Frends.OAuth.CreateJWTToken/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.4.0] - 2025-05-16
+### Changed
+- Fixed early disposal of ECDsa and RSA keys
+- 
 ## [1.3.0] - 2024-08-21
 ### Added
 - Support for new IdentityModel-version.

--- a/Frends.OAuth.CreateJWTToken/Frends.OAuth.CreateJWTToken/Frends.OAuth.CreateJWTToken.csproj
+++ b/Frends.OAuth.CreateJWTToken/Frends.OAuth.CreateJWTToken/Frends.OAuth.CreateJWTToken.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.3.0</Version>
+	<Version>1.4.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where cryptographic keys (ECDsa and RSA) could be prematurely disposed, improving reliability when generating JWT tokens.

- **Documentation**
  - Updated the changelog to include details about the fix in version 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->